### PR TITLE
Allow minimum log level to be set for Spectre console logger

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 0,
-  "Minor": 3,
+  "Minor": 4,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/samples/ExampleCommandApp/Program.cs
+++ b/samples/ExampleCommandApp/Program.cs
@@ -7,7 +7,7 @@ using Spectre.Console.Cli;
 var builder = Host.CreateApplicationBuilder(args);
 
 builder.Logging.ClearProviders()
-    .AddSpectreConsole();
+    .AddSpectreConsole(builder.Configuration);
 
 builder.Services.AddSpectreCommandApp<HelloCommand>(options => {
     options.SetApplicationName("HelloCommandApp");

--- a/src/Jaahas.Spectre.Extensions/Logging/LoggerFactoryExtensions.cs
+++ b/src/Jaahas.Spectre.Extensions/Logging/LoggerFactoryExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -87,6 +88,45 @@ namespace Jaahas.Spectre.Extensions.Logging {
 
             builder.AddSpectreConsole();
             builder.Services.Configure(configure);
+
+            return builder;
+        }
+
+
+        /// <summary>
+        /// Adds a logger to the builder that writes to the console using Spectre.Console.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="ILoggingBuilder"/>.
+        /// </param>
+        /// <param name="configuration">
+        ///   The <see cref="IConfiguration"/> to bind the <see cref="SpectreConsoleLoggerOptions"/> 
+        ///   against.
+        /// </param>
+        /// <param name="configurationSection">
+        ///   The name of the configuration section to bind the options against.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="ILoggingBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        public static ILoggingBuilder AddSpectreConsole(this ILoggingBuilder builder, IConfiguration configuration, string? configurationSection = "SpectreConsoleLogger") {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (configuration == null) {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            builder.AddSpectreConsole();
+            builder.Services.Configure<SpectreConsoleLoggerOptions>(string.IsNullOrWhiteSpace(configurationSection)
+                ? configuration
+                : configuration.GetSection(configurationSection!));
 
             return builder;
         }

--- a/src/Jaahas.Spectre.Extensions/Logging/SpectreConsoleFormatter.cs
+++ b/src/Jaahas.Spectre.Extensions/Logging/SpectreConsoleFormatter.cs
@@ -21,6 +21,11 @@ namespace Jaahas.Spectre.Extensions.Logging {
         /// </summary>
         private readonly SpectreConsoleLoggerOptions _options;
 
+        /// <summary>
+        /// The minimum log level to use.
+        /// </summary>
+        public LogLevel? MinimumLogLevel => _options.MinimumLogLevel;
+
 
         /// <summary>
         /// Creates a new <see cref="SpectreConsoleFormatter"/> with the specified options.

--- a/src/Jaahas.Spectre.Extensions/Logging/SpectreConsoleLogger.cs
+++ b/src/Jaahas.Spectre.Extensions/Logging/SpectreConsoleLogger.cs
@@ -30,6 +30,10 @@ namespace Jaahas.Spectre.Extensions.Logging {
 
         /// <inheritdoc/>
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) {
+            if (!IsEnabled(logLevel)) {
+                return;
+            }
+
             // Do not pass the exception here; we'll write it below using AnsiConsole.WriteException
             // if it is non-null.
             var message = formatter(state, null);
@@ -38,7 +42,7 @@ namespace Jaahas.Spectre.Extensions.Logging {
 
 
         /// <inheritdoc/>
-        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None && (!Formatter.MinimumLogLevel.HasValue || logLevel >= Formatter.MinimumLogLevel.Value);
 
 
         /// <inheritdoc/>

--- a/src/Jaahas.Spectre.Extensions/Logging/SpectreConsoleLoggerOptions.cs
+++ b/src/Jaahas.Spectre.Extensions/Logging/SpectreConsoleLoggerOptions.cs
@@ -1,4 +1,6 @@
-﻿using Spectre.Console;
+﻿using Microsoft.Extensions.Logging;
+
+using Spectre.Console;
 
 namespace Jaahas.Spectre.Extensions.Logging {
 
@@ -6,6 +8,11 @@ namespace Jaahas.Spectre.Extensions.Logging {
     /// Options for a Spectre console logger.
     /// </summary>
     public class SpectreConsoleLoggerOptions {
+
+        /// <summary>
+        /// The minimum log level for <see cref="SpectreConsoleLogger"/> instances.
+        /// </summary>
+        public LogLevel? MinimumLogLevel { get; set; }
 
         /// <summary>
         /// The style to use for critical log messages.


### PR DESCRIPTION
This PR adds a `MinimumLogLevel` property to `SpectreConsoleLoggerOptions` that allows the Spectre console logger to filter out messages that pass the general minimum log level checks.

Also adds a logging provider registration method that binds the `SpectreConsoleLoggerOptions` against an `IConfiguration`.