### PR TITLE
Spectre v0.53.0 breaking changes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,6 @@
     <PackageVersion Include="MSTest" Version="3.9.3" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.53.0" />
-    <PackageVersion Include="Spectre.Console.Testing" Version="0.50.0" />
+    <PackageVersion Include="Spectre.Console.Testing" Version="0.53.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="MSTest" Version="3.9.3" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.50.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.0" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.50.0" />
   </ItemGroup>
 </Project>

--- a/build/version.json
+++ b/build/version.json
@@ -1,5 +1,5 @@
 {
-  "Major": 2,
+  "Major": 3,
   "Minor": 0,
   "Patch": 0,
   "PreRelease": ""

--- a/samples/ExampleCommandApp/HelloCommand.cs
+++ b/samples/ExampleCommandApp/HelloCommand.cs
@@ -15,7 +15,7 @@ namespace ExampleCommandApp {
         }
 
 
-        public override int Execute(CommandContext context, Settings settings) {
+        public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken) {
             AnsiConsole.WriteLine(_helloService.Greet(settings.Name));
             AnsiConsole.WriteLine();
 

--- a/src/Jaahas.Spectre.Extensions.Hosting/JaahasSpectreHostBuilderExtensions.cs
+++ b/src/Jaahas.Spectre.Extensions.Hosting/JaahasSpectreHostBuilderExtensions.cs
@@ -162,10 +162,10 @@ namespace Microsoft.Extensions.Hosting {
         ///   The command arguments.
         /// </param>
         /// <param name="cancellationToken">
-        ///   The cancellation token to use when starting the host.
+        ///   The cancellation token for the command app.
         /// </param>
         /// <returns>
-        ///   The exit code of the command.
+        ///   The exit code of the command app.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="builder"/> is <see langword="null"/>.
@@ -184,7 +184,10 @@ namespace Microsoft.Extensions.Hosting {
             using var host = builder.Build();
             await host.StartAsync(cancellationToken).ConfigureAwait(false);
 
-            return await host.Services.RunSpectreCommandAppAsync(args).ConfigureAwait(false);
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            using var ctSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, lifetime.ApplicationStopping);
+            
+            return await host.Services.RunSpectreCommandAppAsync(args, ctSource.Token).ConfigureAwait(false);
         }
 
 
@@ -201,10 +204,10 @@ namespace Microsoft.Extensions.Hosting {
         ///   The command arguments.
         /// </param>
         /// <param name="cancellationToken">
-        ///   The cancellation token to use when starting the host.
+        ///   The cancellation token for the command app.
         /// </param>
         /// <returns>
-        ///   The exit code of the command.
+        ///   The exit code of the command app.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="builder"/> is <see langword="null"/>.
@@ -222,8 +225,11 @@ namespace Microsoft.Extensions.Hosting {
 
             using var host = builder.Build();
             await host.StartAsync(cancellationToken).ConfigureAwait(false);
+            
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            using var ctSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, lifetime.ApplicationStopping);
 
-            return await host.Services.RunSpectreCommandAppAsync<TDefaultCommand>(args).ConfigureAwait(false);
+            return await host.Services.RunSpectreCommandAppAsync<TDefaultCommand>(args, ctSource.Token).ConfigureAwait(false);
         }
 
 
@@ -237,10 +243,10 @@ namespace Microsoft.Extensions.Hosting {
         ///   The command arguments.
         /// </param>
         /// <param name="cancellationToken">
-        ///   The cancellation token to use when starting the host.
+        ///   The cancellation token for the command app.
         /// </param>
         /// <returns>
-        ///   The exit code of the command.
+        ///   The exit code of the command app.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="builder"/> is <see langword="null"/>.
@@ -258,8 +264,11 @@ namespace Microsoft.Extensions.Hosting {
 
             using var host = builder.Build();
             await host.StartAsync(cancellationToken).ConfigureAwait(false);
+            
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            using var ctSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, lifetime.ApplicationStopping);
 
-            return await host.Services.RunSpectreCommandAppAsync(args).ConfigureAwait(false);
+            return await host.Services.RunSpectreCommandAppAsync(args, ctSource.Token).ConfigureAwait(false);
         }
 
 
@@ -276,10 +285,10 @@ namespace Microsoft.Extensions.Hosting {
         ///   The command arguments.
         /// </param>
         /// <param name="cancellationToken">
-        ///   The cancellation token to use when starting the host.
+        ///   The cancellation token for the command app.
         /// </param>
         /// <returns>
-        ///   The exit code of the command.
+        ///   The exit code of the command app.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="builder"/> is <see langword="null"/>.
@@ -297,8 +306,11 @@ namespace Microsoft.Extensions.Hosting {
 
             using var host = builder.Build();
             await host.StartAsync(cancellationToken).ConfigureAwait(false);
+            
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            using var ctSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, lifetime.ApplicationStopping);
 
-            return await host.Services.RunSpectreCommandAppAsync<TDefaultCommand>(args).ConfigureAwait(false);
+            return await host.Services.RunSpectreCommandAppAsync<TDefaultCommand>(args, ctSource.Token).ConfigureAwait(false);
         }
 
     }

--- a/src/Jaahas.Spectre.Extensions/JaahasSpectreServiceProviderExtensions.cs
+++ b/src/Jaahas.Spectre.Extensions/JaahasSpectreServiceProviderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -21,8 +22,11 @@ namespace System {
         /// <param name="args">
         ///   The command arguments.
         /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token to pass to the command app.
+        /// </param>
         /// <returns>
-        ///   The exit code of the command.
+        ///   The exit code of the command app.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="provider"/> is <see langword="null"/>.
@@ -30,7 +34,7 @@ namespace System {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="args"/> is <see langword="null"/>.
         /// </exception>
-        public static async Task<int> RunSpectreCommandAppAsync(this IServiceProvider provider, IEnumerable<string> args) {
+        public static async Task<int> RunSpectreCommandAppAsync(this IServiceProvider provider, IEnumerable<string> args, CancellationToken cancellationToken = default) {
             if (provider == null) {
                 throw new ArgumentNullException(nameof(provider));
             }
@@ -41,7 +45,7 @@ namespace System {
             using var scope = provider.CreateScope();
             var commandApp = scope.ServiceProvider.GetRequiredService<CommandApp>();
 
-            return await commandApp.RunAsync(args).ConfigureAwait(false);
+            return await commandApp.RunAsync(args, cancellationToken).ConfigureAwait(false);
         }
 
 
@@ -57,8 +61,11 @@ namespace System {
         /// <param name="args">
         ///   The command arguments.
         /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token to pass to the command app.
+        /// </param>
         /// <returns>
-        ///   The exit code of the command.
+        ///   The exit code of the command app.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="provider"/> is <see langword="null"/>.
@@ -66,7 +73,7 @@ namespace System {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="args"/> is <see langword="null"/>.
         /// </exception>
-        public static async Task<int> RunSpectreCommandAppAsync<TDefaultCommand>(this IServiceProvider provider, IEnumerable<string> args) where TDefaultCommand : class, ICommand {
+        public static async Task<int> RunSpectreCommandAppAsync<TDefaultCommand>(this IServiceProvider provider, IEnumerable<string> args, CancellationToken cancellationToken = default) where TDefaultCommand : class, ICommand {
             if (provider == null) {
                 throw new ArgumentNullException(nameof(provider));
             }
@@ -77,7 +84,7 @@ namespace System {
             using var scope = provider.CreateScope();
             var commandApp = scope.ServiceProvider.GetRequiredService<CommandApp<TDefaultCommand>>();
 
-            return await commandApp.RunAsync(args).ConfigureAwait(false);
+            return await commandApp.RunAsync(args, cancellationToken).ConfigureAwait(false);
         }
 
     }


### PR DESCRIPTION
Spectre v0.53.0 makes breaking changes to the Command and AsyncCommand base types, and to the CommandApp.RunAsync method to support cancellation.

This PR brings binary compatibility with that version, and improves cancellation when running command apps.